### PR TITLE
As of luvi v1.1.0 the variants have changed

### DIFF
--- a/lib/luvi/README.md
+++ b/lib/luvi/README.md
@@ -6,9 +6,8 @@
 
 [luvi] variants are:-
 
-* `large`
-* `static`
-* `tiny`
+* `regular` - with openssl
+* `tiny` - without openssl
 
 ## Operating Systems
 


### PR DESCRIPTION
None come with zlib by default and the only variants are `tiny` with it bare and `regular` which has openssl statically included.
